### PR TITLE
Remove skeleton NPC and blob logic

### DIFF
--- a/assets/js/consequences.js
+++ b/assets/js/consequences.js
@@ -1,4 +1,4 @@
-﻿import { BARRIER_PATH, CAPYBARA_PATH, COFFEE_MUG_PATH, SKELETON_PATH } from './constants.js';
+import { BARRIER_PATH, CAPYBARA_PATH, COFFEE_MUG_PATH } from './constants.js';
 import { gameState, worldState, selectors, runtimeState, audioState } from './state.js';
 import { setAssetActive } from './assetManager.js';
 import { flashGlitchOverlay } from './ui.js';
@@ -70,19 +70,6 @@ export function applyConsequences(path) {
       break;
     case 'core/runtime/System.exe':
       triggerFinalEvent();
-      break;
-    case SKELETON_PATH:
-      if (worldState.skeleton.active) {
-        worldState.skeleton.active = false;
-        worldState.skeleton.blobbed = true;
-        worldState.skeleton.animationFrame = 0;
-        worldState.skeleton.animationTimer = 0;
-        worldState.skeleton.y = worldState.skeleton.baseY;
-        worldState.skeleton.present = worldState.currentScene === worldState.skeleton.sceneIndex;
-        setAssetActive(SKELETON_PATH, false);
-        flashGlitchOverlay('Skeleton dissolves into a blob.');
-        playGlitchSound();
-      }
       break;
     case BARRIER_PATH:
       if (worldState.barrierPresent) {

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -1,4 +1,4 @@
-﻿export const INITIAL_FILESYSTEM = {
+export const INITIAL_FILESYSTEM = {
   textures: {
     avatars: ['Player.png'],
     props: {
@@ -29,7 +29,7 @@
   },
   world: {
     barriers: ['ObsidianWall.asset'],
-    fauna: ['Capybara.png', 'Skelleton.anim'],
+    fauna: ['Capybara.png'],
   },
 };
 
@@ -49,7 +49,6 @@ export const CONSEQUENCE_DESCRIPTIONS = {
   'core/runtime/System.exe': 'Core system terminated.',
   'world/barriers/ObsidianWall.asset': 'Brick barrier removed from the Archive.',
   'world/fauna/Capybara.png': 'Capybara companion retreats beyond the veil.',
-  'world/fauna/Skelleton.anim': 'Skeleton liquefies into a shimmering blob.',
   'core/security/reality_anchor.sys': 'Reality anchor destabilized. System collapse imminent.',
   'core/security/quantum_stability.dat': 'Quantum coherence lost. Reality fracturing.',
   'core/security/consciousness_stream.bin': 'Consciousness stream severed. Existence compromised.',
@@ -68,7 +67,6 @@ export const FILE_ASSET_MAP = {
   'world/barriers/ObsidianWall.asset': 'assets/gfx/wall_brick.png',
   'textures/props/beverages/CoffeeMug.png': 'assets/gfx/coffee_placeholder.png',
   'world/fauna/Capybara.png': 'assets/gfx/capybara.png',
-  'world/fauna/Skelleton.anim': 'assets/gfx/blobanimation.png',
 };
 
 export const TEXTURE_PLACEHOLDER_SRC = 'assets/gfx/texture_missing.png';
@@ -89,12 +87,6 @@ export const COFFEE_MUG_PATH = 'textures/props/beverages/CoffeeMug.png';
 export const CHARACTER_SPRITE_COLUMNS = 2;
 export const CHARACTER_SPRITE_ROWS = 2;
 export const CHARACTER_ANIMATION_FPS = 2;
-
-export const SKELETON_PATH = 'world/fauna/Skelleton.anim';
-export const SKELETON_SPRITE_COLUMNS = 6;
-export const SKELETON_SPRITE_ROWS = 4;
-export const SKELETON_ANIMATION_FPS = 16;
-export const BLOB_PLACEHOLDER_SRC = 'assets/gfx/blob_placeholder.png';
 
 export const CAPYBARA_PATH = 'world/fauna/Capybara.png';
 export const CAPYBARA_SCENE_ID = 'sanctum';

--- a/assets/js/state.js
+++ b/assets/js/state.js
@@ -1,4 +1,4 @@
-﻿import { INITIAL_FILESYSTEM, SCENES, COYOTE_TIME, CAPYBARA_SCENE_ID } from './constants.js';
+import { INITIAL_FILESYSTEM, SCENES, COYOTE_TIME, CAPYBARA_SCENE_ID } from './constants.js';
 import { cloneFilesystem, countTotalFiles } from './utils.js';
 const CAPYBARA_SCENE_INDEX = SCENES.findIndex(function (scene) {
   return scene.id === CAPYBARA_SCENE_ID;
@@ -74,13 +74,6 @@ export const worldState = {
     baseY: 0,
     bobPhase: 0,
     sceneIndex: DEFAULT_CAPYBARA_SCENE_INDEX,
-  },
-  playerMorph: {
-    animating: false,
-    completed: false,
-    animationFrame: 0,
-    animationTimer: 0,
-    deactivateSkeletonAsset: false,
   },
 };
 

--- a/assets/js/world.js
+++ b/assets/js/world.js
@@ -1,4 +1,4 @@
-﻿import {
+import {
   TILE_SIZE,
   GROUND_SURFACE_OFFSET,
   SCENES,
@@ -11,27 +11,16 @@
   CHARACTER_ASSET_PATH,
   COFFEE_MUG_PATH,
   CAPYBARA_PATH,
-  SKELETON_PATH,
   CHARACTER_SPRITE_COLUMNS,
   CHARACTER_SPRITE_ROWS,
   CHARACTER_ANIMATION_FPS,
-  SKELETON_SPRITE_COLUMNS,
-  SKELETON_SPRITE_ROWS,
-  SKELETON_ANIMATION_FPS,
-  BLOB_PLACEHOLDER_SRC,
   physicsState,
   COYOTE_TIME,
 } from './constants.js';
 import { worldState, inputState, selectors, runtimeState } from './state.js';
-import { getActiveImage, getPlaceholderImage, setAssetActive } from './assetManager.js';
-import { loadImage } from './utils.js';
+import { getActiveImage, getPlaceholderImage } from './assetManager.js';
 import { playJumpSound, playGlitchSound } from './audio.js';
 import { flashGlitchOverlay } from './ui.js';
-
-
-
-const blobPlaceholderImage = loadImage(BLOB_PLACEHOLDER_SRC);
-const SKELETON_TOTAL_FRAMES = Math.max(1, SKELETON_SPRITE_COLUMNS * SKELETON_SPRITE_ROWS);
 
 export function resetWorldState() {
   worldState.started = false;
@@ -71,13 +60,6 @@ export function resetWorldState() {
   capy.x = Math.max(120, selectors.canvas.width - capy.width - 140);
   capy.baseY = surfaceY - capy.height;
   capy.y = capy.baseY;
-
-  const playerMorph = worldState.playerMorph;
-  playerMorph.animating = false;
-  playerMorph.completed = false;
-  playerMorph.animationFrame = 0;
-  playerMorph.animationTimer = 0;
-  playerMorph.deactivateSkeletonAsset = false;
 
   inputState.left = false;
   inputState.right = false;
@@ -226,7 +208,6 @@ export function updateWorld(dt) {
     player.animationTimer = 0;
   }
   updateMugState(dt, physics, groundY);
-  updateSkeleton(dt, groundY);
   updateCapybara(dt, groundY);
 
   if (worldState.physicsBroken) {
@@ -273,7 +254,6 @@ export function drawScene() {
   if (worldState.mugPresent) {
     drawMug(ctx, scene);
   }
-  drawSkeleton(ctx, scene);
   drawCapybara(ctx, scene);
   drawPlayer(ctx, scene);
   drawBarrier(ctx, scene, baseY);
@@ -323,32 +303,6 @@ function updateMugState(dt, physics, groundY) {
     mug.y = groundY - mug.height;
   }
 }
-
-function updatePlayerMorph(dt) {
-  const morph = worldState.playerMorph;
-  if (!morph.animating) {
-    return;
-  }
-  const frameDuration = SKELETON_ANIMATION_FPS > 0 ? 1 / SKELETON_ANIMATION_FPS : 0.0625;
-  morph.animationTimer += dt;
-  while (morph.animationTimer >= frameDuration) {
-    morph.animationTimer -= frameDuration;
-    morph.animationFrame += 1;
-    if (morph.animationFrame >= SKELETON_TOTAL_FRAMES) {
-      morph.animating = false;
-      morph.completed = true;
-      morph.animationFrame = SKELETON_TOTAL_FRAMES - 1;
-      morph.animationTimer = 0;
-      if (morph.deactivateSkeletonAsset) {
-        setAssetActive(SKELETON_PATH, false);
-        morph.deactivateSkeletonAsset = false;
-      }
-      break;
-    }
-  }
-}
-
-
 
 function updateCapybara(dt, groundY) {
   const capy = worldState.capybara;
@@ -646,7 +600,9 @@ function drawCapybara(ctx, scene) {
   }
 
   ctx.restore();
-}function drawBarrier(ctx, scene, groundY) {
+}
+
+function drawBarrier(ctx, scene, groundY) {
   if (!worldState.barrierPresent || worldState.currentScene !== BARRIER_SCENE_INDEX) {
     return;
   }


### PR DESCRIPTION
## Summary
- remove skeleton asset and blob placeholder references from constants and consequences
- simplify world state by dropping skeleton/player morph tracking and related updates
- update world rendering to only handle remaining mug, capybara, and barrier elements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d890fce7c883258de6ef83c2c1550d