### PR TITLE
Flatten explorer and add lethal trap files

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -77,6 +77,10 @@ body {
   box-shadow: 0 18px 40px rgba(0, 0, 0, 0.25);
 }
 
+.explorer {
+  overflow: hidden;
+}
+
 .explorer-header,
 .log-panel h2 {
   display: flex;
@@ -173,6 +177,7 @@ body {
   display: none !important;
 }
 
+#folder-container,
 #log-list {
   list-style: none;
   margin: 0;
@@ -182,6 +187,11 @@ body {
   gap: 0.5rem;
   overflow-y: auto;
   flex: 1;
+}
+
+#folder-container {
+  min-height: 0;
+  padding-right: 0.35rem;
 }
 
 .log-entry {
@@ -269,18 +279,6 @@ body {
 
 .file-entry:hover {
   background: rgba(255, 255, 255, 0.07);
-}
-
-.file-entry[data-depth="1"] {
-  margin-left: 1rem;
-}
-
-.file-entry[data-depth="2"] {
-  margin-left: 1.75rem;
-}
-
-.file-entry[data-depth="3"] {
-  margin-left: 2.5rem;
 }
 
 .file-entry.burning::after {
@@ -389,6 +387,11 @@ body {
   background: transparent;
   border: 1px dashed rgba(255, 255, 255, 0.08);
   pointer-events: none;
+}
+
+.file-path {
+  flex: 1;
+  word-break: break-all;
 }
 
 .log-entry strong {

--- a/assets/js/consequences.js
+++ b/assets/js/consequences.js
@@ -21,6 +21,10 @@ export function applyConsequences(path) {
     case 'core/security/quantum_stability.dat':
     case 'core/security/consciousness_stream.bin':
     case 'core/security/dream_fragments.mem':
+    case 'core/security/failsafe_override.key':
+    case 'core/security/entropy_lattice.cfg':
+    case 'core/security/soul_vault.lock':
+    case 'core/security/timeline_anchor.log':
       triggerFinalEvent();
       break;
     case 'textures/environment/backgrounds/Background.png':

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -25,7 +25,16 @@ export const INITIAL_FILESYSTEM = {
   core: {
     subsystems: ['Physics.dll'],
     runtime: ['System.exe'],
-    security: ['reality_anchor.sys', 'quantum_stability.dat', 'consciousness_stream.bin', 'dream_fragments.mem']
+    security: [
+      'reality_anchor.sys',
+      'quantum_stability.dat',
+      'consciousness_stream.bin',
+      'dream_fragments.mem',
+      'failsafe_override.key',
+      'entropy_lattice.cfg',
+      'soul_vault.lock',
+      'timeline_anchor.log'
+    ]
   },
   world: {
     barriers: ['ObsidianWall.asset'],
@@ -52,7 +61,11 @@ export const CONSEQUENCE_DESCRIPTIONS = {
   'core/security/reality_anchor.sys': 'Reality anchor destabilized. System collapse imminent.',
   'core/security/quantum_stability.dat': 'Quantum coherence lost. Reality fracturing.',
   'core/security/consciousness_stream.bin': 'Consciousness stream severed. Existence compromised.',
-  'core/security/dream_fragments.mem': 'Dream fragments scattered. The void beckons.'
+  'core/security/dream_fragments.mem': 'Dream fragments scattered. The void beckons.',
+  'core/security/failsafe_override.key': 'Failsafe override tripped. Shutdown cascade triggered.',
+  'core/security/entropy_lattice.cfg': 'Entropy lattice collapsed. Structure unwinding.',
+  'core/security/soul_vault.lock': 'Soul vault breached. Containment shattered.',
+  'core/security/timeline_anchor.log': 'Timeline anchor erased. Reality slipping out of sync.'
 };
 
 export const TILE_SIZE = 48;


### PR DESCRIPTION
## Summary
- replace the folder-based explorer with a flat, scrollable list of every file path
- introduce new high-risk security files that immediately collapse the system when deleted
- refresh styles so the explorer supports long path labels and smooth scrolling

## Testing
- Manual UI verification

------
https://chatgpt.com/codex/tasks/task_e_68d896da18c083258a4d662302de1d43