### PR TITLE
Limit scrolling to explorer pane

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -15,6 +15,11 @@
   box-sizing: border-box;
 }
 
+html,
+body {
+  height: 100%;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
@@ -22,6 +27,7 @@ body {
   color: var(--text);
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .top-bar {
@@ -61,10 +67,12 @@ body {
 
 .app-shell {
   flex: 1;
+  min-height: 0;
   display: grid;
   gap: 1rem;
   padding: 1rem 1.5rem 1.5rem;
   grid-template-columns: 260px minmax(0, 1fr) 260px;
+  overflow: hidden;
 }
 
 .explorer,
@@ -79,6 +87,7 @@ body {
 
 .explorer {
   overflow: hidden;
+  min-height: 0;
 }
 
 .explorer-header,


### PR DESCRIPTION
## Summary
- prevent page-level scrolling so only the explorer list scrolls
- ensure the application shell keeps a fixed viewport height while the game canvas stays centered

## Testing
- Manual inspection in browser

------
https://chatgpt.com/codex/tasks/task_e_68d8983de9bc8325b5253431b9021c47