### PR TITLE
Improve file explorer readability

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -260,7 +260,7 @@ body {
 
 .file-entry {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   margin: 0.4rem 0;
   padding: 0.35rem 0.55rem;
@@ -269,7 +269,7 @@ body {
   font-size: 0.85rem;
   gap: 0.5rem;
   position: relative;
-  overflow: hidden;
+  flex-wrap: wrap;
   transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
@@ -279,6 +279,8 @@ body {
   color: var(--danger);
   cursor: pointer;
   font-size: 1rem;
+  flex-shrink: 0;
+  align-self: center;
   transition: transform 0.2s ease;
 }
 
@@ -400,7 +402,9 @@ body {
 
 .file-path {
   flex: 1;
-  word-break: break-all;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .log-entry strong {


### PR DESCRIPTION
## Summary
- allow file explorer rows to wrap so long file paths remain fully visible
- prevent the delete button from shrinking while keeping alignment consistent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8990333748325bc447963e134c14e